### PR TITLE
Add MapTiler as a map provider

### DIFF
--- a/src/scripts/ethosmaps/lib/tileloader.lua
+++ b/src/scripts/ethosmaps/lib/tileloader.lua
@@ -187,7 +187,7 @@ local function loadTileFromDisk(tilePath)
     attemptedPaths    = { onlyPath }
     bmp, loadedPath   = loadFirstExisting(tilePath, onlyPath)
   else
-    local PROVIDER_FOLDERS = { [2] = "GOOGLE", [3] = "ESRI", [4] = "OSM" }
+    local PROVIDER_FOLDERS = { [2] = "GOOGLE", [3] = "ESRI", [4] = "OSM", [5] = "MAPTILER" }
     local folder = PROVIDER_FOLDERS[provider] or ("PROVIDER" .. tostring(provider))
     local base   = "/bitmaps/ethosmaps/maps/" .. folder .. "/" .. mapType .. tilePath
 

--- a/src/scripts/ethosmaps/main.lua
+++ b/src/scripts/ethosmaps/main.lua
@@ -1957,6 +1957,7 @@ local MAP_TYPE_LABELS = {
   [6] = "Outdoor",
   [7] = "Topo",
   [8] = "Winter",
+  [9] = "OSM Style",
 }
 
 -- On-disk folder names for each map provider under /bitmaps/ethosmaps/maps/
@@ -2028,13 +2029,14 @@ local function getMapTypeFolder(provider, mapTypeId)
     return nil
   end
   if provider == 5 then
-    -- MapTiler: Satellite, Hybrid, Street, plus MapTiler-only Outdoor, Topo, Winter.
+    -- MapTiler: Satellite, Hybrid, Street, plus MapTiler-only Outdoor, Topo, Winter, OSM Style.
     if mapTypeId == 1 then return "Satellite" end
     if mapTypeId == 2 then return "Hybrid" end
     if mapTypeId == 5 then return "Street" end
     if mapTypeId == 6 then return "Outdoor" end
     if mapTypeId == 7 then return "Topo" end
     if mapTypeId == 8 then return "Winter" end
+    if mapTypeId == 9 then return "OSM Style" end
     return nil
   end
   -- Google (provider 2): Satellite, Hybrid, Map, Terrain.
@@ -2097,7 +2099,7 @@ local function getAvailableProviderChoices(forceRefresh)
   local choices = {}
   for provider=1,5 do
     local available = false
-    for typeId=1,8 do
+    for typeId=1,9 do
       if mapTypeFolderExists(provider, typeId) then
         available = true
         break
@@ -2120,7 +2122,7 @@ local function getAvailableMapTypeChoices(provider, forceRefresh)
   end
 
   local choices = {}
-  for typeId=1,8 do
+  for typeId=1,9 do
     local folder = getMapTypeFolder(provider, typeId)
     if folder ~= nil and mapTypeFolderExists(provider, typeId) then
       tinsert(choices, {MAP_TYPE_LABELS[typeId], typeId})

--- a/src/scripts/ethosmaps/main.lua
+++ b/src/scripts/ethosmaps/main.lua
@@ -1945,6 +1945,7 @@ local MAP_PROVIDER_LABELS = {
   [2] = "Google",
   [3] = "ESRI",
   [4] = "OSM",
+  [5] = "MapTiler",
 }
 
 local MAP_TYPE_LABELS = {
@@ -1953,6 +1954,9 @@ local MAP_TYPE_LABELS = {
   [3] = "Map",
   [4] = "Terrain",
   [5] = "Street",
+  [6] = "Outdoor",
+  [7] = "Topo",
+  [8] = "Winter",
 }
 
 -- On-disk folder names for each map provider under /bitmaps/ethosmaps/maps/
@@ -1960,6 +1964,7 @@ local PROVIDER_FOLDER_NAMES = {
   [2] = "GOOGLE",
   [3] = "ESRI",
   [4] = "OSM",
+  [5] = "MAPTILER",
 }
 
 local function directoryExists(path)
@@ -2022,6 +2027,16 @@ local function getMapTypeFolder(provider, mapTypeId)
     if mapTypeId == 5 then return "Street" end
     return nil
   end
+  if provider == 5 then
+    -- MapTiler: Satellite, Hybrid, Street, plus MapTiler-only Outdoor, Topo, Winter.
+    if mapTypeId == 1 then return "Satellite" end
+    if mapTypeId == 2 then return "Hybrid" end
+    if mapTypeId == 5 then return "Street" end
+    if mapTypeId == 6 then return "Outdoor" end
+    if mapTypeId == 7 then return "Topo" end
+    if mapTypeId == 8 then return "Winter" end
+    return nil
+  end
   -- Google (provider 2): Satellite, Hybrid, Map, Terrain.
   if mapTypeId == 1 then return "Satellite" end
   if mapTypeId == 2 then return "Hybrid" end
@@ -2080,9 +2095,9 @@ end
 
 local function getAvailableProviderChoices(forceRefresh)
   local choices = {}
-  for provider=1,4 do
+  for provider=1,5 do
     local available = false
-    for typeId=1,5 do
+    for typeId=1,8 do
       if mapTypeFolderExists(provider, typeId) then
         available = true
         break
@@ -2105,7 +2120,7 @@ local function getAvailableMapTypeChoices(provider, forceRefresh)
   end
 
   local choices = {}
-  for typeId=1,5 do
+  for typeId=1,8 do
     local folder = getMapTypeFolder(provider, typeId)
     if folder ~= nil and mapTypeFolderExists(provider, typeId) then
       tinsert(choices, {MAP_TYPE_LABELS[typeId], typeId})


### PR DESCRIPTION
Hi Mark! This follows up on #48 and adds MapTiler as a map provider.

It shows up as a new "MapTiler" provider with its own MAPTILER folder under bitmaps/ethosmaps/maps/. On top of the usual Satellite, Hybrid and Street, I also added MapTiler's Outdoor, Topo and Winter styles, since MapTiler has them and they're nice to have. Personally I really like Topo and Winter — they're light and bright, so they read really well on the radio screen in daylight.

I tried hard not to disturb anything that already works. MapTiler tiles are plain XYZ (/z/x/y), the same as Google, so I didn't need to touch any of the projection code in maplib. And since the widget only lists a provider or map type when its folder is аctually on the card, Google/ESRI/OSM/GMapCatcher users won't notice any difference — the new map-type IDs just come back nil for them. So the change really comes down to: register the provider and the three extra map types, point them at their folders, tell tileloader about the MAPTILER folder, and widen the two availability scans so the new entries get picked up.

I tested it on my FrSky X20RS MapTiler appears in the provider list and all six map types draw correctly, using tiles I made with the High-Res Map Generator (b14ckyy target) — it writes them to `bitmaps/ethosmaps/maps/MAPTILER/<MapType>/<z>/<x>/<y>.jpg`.

Here's the Topo style on my X20RS:
<img width="800" height="480" alt="Topo" src="https://github.com/user-attachments/assets/dc9f9680-91e4-42cd-bef7-843e62fe4d86" />


Let me know if you'd like anything done differently.
